### PR TITLE
Add Multilingual Transcript Caching and Retrieval Logic to `/simple-transcript-v3`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 
 firebaseServiceAccount.json
 ecosystem.config.js
+*.excalidraw

--- a/documentation.md
+++ b/documentation.md
@@ -117,9 +117,77 @@ This endpoint returns a simplified version of the transcript, which includes the
 - **`title`**: Title of the video.
 - **`transcript`**: Full transcript as a concatenated string.
 
+
+
+
+
+
+Perfect — here’s a clean and concise version for **API docs / OpenAPI / Swagger style documentation**:
+
 ---
 
-### 3. **POST `/smart-transcript`**
+### 3. **POST `/simple-transcript-v3`**
+
+**Description**
+Fetches and returns the transcript of a YouTube video in a requested language (or default language if not specified). Caches transcripts per language for faster future access.
+
+**Request Body**
+
+```json
+{
+  "url": "string (required) - YouTube video URL",
+  "lang": "string (optional) - Language code (e.g. en, es, en-US)"
+}
+```
+
+**Response 200**
+
+```json
+{
+  "videoID": "string",
+  "duration": "number (minutes)",
+  "title": "string",
+  "transcript": "string",
+  "transcriptLanguageCode": "string",
+  "languages": [
+    { "code": "string" }
+  ],
+  "videoInfoSummary": {
+    "author": "string",
+    "description": "string",
+    "embed": "object",
+    "thumbnails": "array",
+    "viewCount": "string",
+    "publishDate": "string",
+    "video_url": "string"
+  }
+}
+```
+
+**Response 404**
+
+```json
+{
+  "message": "No captions available for this video."
+}
+```
+
+**Response 500**
+
+```json
+{
+  "message": "An error occurred while fetching and saving the transcript."
+}
+```
+
+**Notes**
+
+* `languages` is only included if more than one caption language is available.
+* Cached transcripts are automatically updated and stored by video ID and language.
+
+---
+
+### 4. **POST `/smart-transcript`**
 
 This endpoint checks Firestore for an existing transcript for the specified YouTube video. If it exists, the cached version is returned. If not, it fetches the transcript, stores it in Firestore, and returns the result.
 
@@ -151,7 +219,7 @@ This endpoint checks Firestore for an existing transcript for the specified YouT
 
 ---
 
-### 4. **POST `/smart-summary`**
+### 5. **POST `/smart-summary`**
 
 This endpoint checks Firestore for a summary of the specified YouTube video. If a summary exists, it is returned from the cache. If not, the service uses the provided transcript (or fetches it from YouTube) and generates a summary using a model (e.g., ChatGPT).
 
@@ -183,7 +251,7 @@ This endpoint checks Firestore for a summary of the specified YouTube video. If 
 
 ---
 
-### 5. **POST `/smart-summary-firebase`**
+### 6. **POST `/smart-summary-firebase`**
 
 This endpoint operates similarly to `/smart-summary`, but it offloads the summary generation and caching to Firestore itself. It sends only the video ID to a model to generate the summary, stores it in Firestore, and returns the summary.
 

--- a/index.js
+++ b/index.js
@@ -382,10 +382,12 @@ app.post('/simple-transcript-v3', async (req, res) => {
 
       // Fallback to match language prefix (en vs en-US)
       if (!cachedTranscript && lang) {
+        console.log(`No exact match for ${lang}, trying prefix match...`);
         cachedTranscript = cached.transcript.find(t => t.language.startsWith(lang));
       }
 
       if (cachedTranscript) {
+        console.log(`Transcript found in Firebase for ${videoId} in ${lang}`);
         return res.json({
           videoID: cached.videoID,
           duration: cached.duration,

--- a/index.js
+++ b/index.js
@@ -462,6 +462,7 @@ app.post('/simple-transcript-v3', async (req, res) => {
     res.json({
       videoID: videoId,
       duration: duration,
+      title: videoInfo.videoDetails.title,
       transcript: selectedTranscriptText,
       transcriptLanguageCode: selectedLanguageCode,
       languages: languages.length > 1 ? languages : undefined,


### PR DESCRIPTION
### Summary

This PR introduces major improvements to the `/simple-transcript-v3` endpoint to support multilingual transcript caching, retrieval, and optimized responses.
The updated logic ensures transcripts are cached per language, avoids redundant fetching, and improves consistency and performance.

---

### Changes

* Added support for **progressive multilingual transcript caching**.

  * Each transcript is stored in Firestore under `transcript` array with `language`, `title`, and `transcript` fields.
  * New language transcripts are fetched and appended when requested.

* Added `availableLanguages` field in Firestore:

  * Saved during the first fetch of a video.
  * Returned with every response to allow clients to display all available caption languages.

* Implemented fallback logic:

  * If no language is requested → returns the first cached transcript.
  * If requested language is cached → returns cached transcript.
  * If requested language is NOT cached → fetches from YouTube, saves, and returns the transcript.

* Improved consistency:

  * Cached transcripts always return `availableLanguages` from Firestore (no need to re-fetch video info).
  * Unified response structure regardless of cache state.

* Improved performance:

  * Reduced unnecessary YouTube API calls.
  * Minimized processing when transcripts are already cached.

---

### Additional Updates

* Added OpenAPI 3.0 specification to document the endpoint.
* Generated Postman collection for easier local and remote testing.

---

### Benefits

* Faster transcript retrieval on subsequent requests.
* Full support for on-demand multilingual transcript fetching.
* Optimized cache storage and lookup strategy.
* Clean and structured API responses for frontend clients.

---

### Next steps / Optional

* Add endpoint for refreshing `availableLanguages` if new captions are added to YouTube videos.
