### PR TITLE
Add metada summary markdown file firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,36 @@ This endpoint checks if the transcript is already stored in Firestore. If found,
 
 ---
 
+### 🧠 POST `/smart-transcript-v2`
+
+Fetches the transcript and metadata for a YouTube video, stores it in Firestore if not already present.
+
+**Request:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID"
+}
+```
+
+**Response:**
+
+```json
+{
+  "videoId": "VIDEO_ID",
+  "title": "Video Title",
+  "duration": 14,
+  "transcript": "Transcript text...",
+  "description": "First line of the video description",
+  "date": "2025-01-26",
+  "image": "https://i.ytimg.com/vi/VIDEO_ID/maxresdefault.jpg",
+  "tags": ["ios", "automation", "shortcuts"],
+  "canonical_url": "https://blog.andreszenteno.com/notes/video-title"
+}
+```
+
+---
+
 ### 🧠 POST `/smart-summary`
 
 This endpoint checks Firestore for a summary of the video. If one exists, it's returned. If not, it uses the **ChatGPT API** to generate the summary (using the transcript), stores it in Firestore, and returns it.
@@ -263,6 +293,34 @@ This endpoint provides similar functionality to `/smart-summary` but offloads th
   "fromCache": true
 }
 ```
+
+---
+
+### ✅ POST `/smart-summary-firebase-v2`
+
+Generates a markdown-formatted AI summary with frontmatter and tags. Caches both in Firestore.
+
+**Request:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
+  "model": "openai"
+}
+```
+
+**Response:**
+
+```json
+{
+  "summary": "---\ntitle: \"...\"\ndate: ...\ntags: [...]\n---\nSummary content...",
+  "fromCache": false
+}
+```
+
+* Uses OpenAI to generate both the summary and tags.
+* Saves results to both `summaries` and `transcripts` collections in Firestore.
+* Includes YouTube link and properly formatted frontmatter for markdown usage.
 
 ---
 

--- a/documentation.md
+++ b/documentation.md
@@ -10,7 +10,67 @@ This Express-based service fetches YouTube video information (metadata) and tran
 
 ## **Service Endpoints**
 
-### 1. **POST `/transcript`**
+### 1. **POST `/smart-transcript-v2`**
+
+**Description**
+Checks Firestore for a transcript of the YouTube video. If missing, fetches transcript, title, description, date, image, inferred tags, and stores them all in Firestore.
+
+**Request Body:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID"
+}
+```
+
+**Response 200:**
+
+```json
+{
+  "videoId": "VIDEO_ID",
+  "title": "Video Title",
+  "duration": 14,
+  "transcript": "Full transcript text...",
+  "description": "First line of the video description",
+  "date": "2025-01-26",
+  "image": "https://i.ytimg.com/vi/VIDEO_ID/maxresdefault.jpg",
+  "tags": ["ios", "automation", "shortcuts"],
+  "canonical_url": "https://blog.andreszenteno.com/notes/video-title"
+}
+```
+
+---
+
+### 2. **POST `/smart-summary-firebase-v2`**
+
+**Description**
+Checks Firestore for an existing summary. If not found, generates an AI-powered summary and tags using OpenAI, formats it with Markdown frontmatter, and saves it to `summaries` and `transcripts` collections.
+
+**Request Body:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
+  "model": "openai"
+}
+```
+
+**Response 200:**
+
+```json
+{
+  "summary": "---\ntitle: \"Video Title\"\ndate: 2025-01-26\ntags:\n  - ios\n  - automation\n  - shortcuts\n---\n...summary...",
+  "fromCache": false
+}
+```
+
+* Uses the deployed AI service `/api/openai-chat-youtube-transcript-v2` to fetch `summary` and `tags`.
+* Markdown-compatible output can be used in Obsidian, static blogs, etc.
+* Tags are stored in both collections for indexing and reuse.
+
+---
+
+### 3. **POST `/transcript`**
 
 This endpoint retrieves full YouTube video information and timestamped captions (subtitles) in all available languages. It fetches video metadata (e.g., title, description, etc.) and subtitles (with timestamps) for all languages supported by the video.
 
@@ -89,7 +149,7 @@ This endpoint retrieves full YouTube video information and timestamped captions 
 
 ---
 
-### 2. **POST `/simple-transcript`**
+### 4. **POST `/simple-transcript`**
 
 This endpoint returns a simplified version of the transcript, which includes the video title and a concatenated string of subtitles in the first available language.
 
@@ -126,7 +186,7 @@ Perfect — here’s a clean and concise version for **API docs / OpenAPI / Swag
 
 ---
 
-### 3. **POST `/simple-transcript-v3`**
+### 5. **POST `/simple-transcript-v3`**
 
 **Description**
 Fetches and returns the transcript of a YouTube video in a requested language (or default language if not specified). Caches transcripts per language for faster future access.
@@ -187,7 +247,7 @@ Fetches and returns the transcript of a YouTube video in a requested language (o
 
 ---
 
-### 4. **POST `/smart-transcript`**
+### 6. **POST `/smart-transcript`**
 
 This endpoint checks Firestore for an existing transcript for the specified YouTube video. If it exists, the cached version is returned. If not, it fetches the transcript, stores it in Firestore, and returns the result.
 
@@ -219,7 +279,7 @@ This endpoint checks Firestore for an existing transcript for the specified YouT
 
 ---
 
-### 5. **POST `/smart-summary`**
+### 7. **POST `/smart-summary`**
 
 This endpoint checks Firestore for a summary of the specified YouTube video. If a summary exists, it is returned from the cache. If not, the service uses the provided transcript (or fetches it from YouTube) and generates a summary using a model (e.g., ChatGPT).
 
@@ -251,7 +311,7 @@ This endpoint checks Firestore for a summary of the specified YouTube video. If 
 
 ---
 
-### 6. **POST `/smart-summary-firebase`**
+### 8. **POST `/smart-summary-firebase`**
 
 This endpoint operates similarly to `/smart-summary`, but it offloads the summary generation and caching to Firestore itself. It sends only the video ID to a model to generate the summary, stores it in Firestore, and returns the summary.
 
@@ -281,7 +341,7 @@ This endpoint operates similarly to `/smart-summary`, but it offloads the summar
 
 ---
 
-### 6. **GET `/health`**
+### 9. **GET `/health`**
 
 A simple health check endpoint to verify that the service is running.
 
@@ -293,7 +353,7 @@ OK
 
 ---
 
-### 7. **GET `/debug`**
+### 10. **GET `/debug`**
 
 A debug endpoint that returns the IP address and region of the requestor.
 

--- a/index.js
+++ b/index.js
@@ -1013,18 +1013,18 @@ app.post('/smart-summary-firebase-v2', async (req, res) => {
 
     // Format frontmatter from metadata
     const frontmatter = `---
-      title: "${metadata.title}"\n
-      date: ${metadata.date}\n
-      description: |
-        ${metadata.description}\n
-      image: '${metadata.image}'\n
-      tags:
-        - youtube
-      ${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
-      canonical_url: ${metadata.canonical_url}\n
-      author: ${metadata.author}
-      ---\n\n
-      # ${metadata.title}\n`;
+title: "${metadata.title}"
+date: ${metadata.date}
+description: |
+  ${metadata.description}
+image: '${metadata.image}'
+tags:
+  - youtube
+${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
+canonical_url: ${metadata.canonical_url}\n
+author: ${metadata.author}
+---\n\n
+# ${metadata.title}\n`;
 
     const summaryWithFrontmatter = `${frontmatter}${plainSummary}`;
 

--- a/index.js
+++ b/index.js
@@ -671,6 +671,21 @@ app.post('/smart-transcript', async (req, res) => {
   }
 });
 
+/**
+ * @route POST /smart-transcript-v2
+ * @description Fetches the transcript and basic metadata for a YouTube video and stores it in Firestore.
+ * @param {Object} req.body - The request payload.
+ * @param {string} req.body.url - The full YouTube video URL.
+ * @returns {Object} 200 - Returns stored transcript and metadata (title, duration, date, tags, etc.).
+ * @returns {Object} 404 - If no transcript is available for the video.
+ * @returns {Object} 500 - If an internal error occurs during processing.
+ *
+ * @example
+ * POST /smart-transcript-v2
+ * {
+ *   "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+ * }
+ */
 app.post('/smart-transcript-v2', async (req, res) => {
   try {
     const { url } = req.body;
@@ -966,6 +981,26 @@ app.post('/smart-summary-firebase', async (req, res) => {
   }
 });
 
+/**
+ * @route POST /smart-summary-firebase-v2
+ * @description Generates an AI-powered summary and tags for a YouTube video's transcript.
+ *              Uses existing transcript metadata from Firestore and enriches it with AI-generated content.
+ *              Stores the result (with YAML frontmatter) in the `summaries` collection and updates tags in `transcripts`.
+ * @param {Object} req.body - The request payload.
+ * @param {string} req.body.url - The full YouTube video URL.
+ * @param {string} req.body.model - The model key used to route to the correct OpenAI/Vercel endpoint.
+ * @returns {Object} 200 - Returns the formatted markdown summary with frontmatter.
+ * @returns {Object} 400 - If URL or model is missing or invalid.
+ * @returns {Object} 404 - If transcript data is missing.
+ * @returns {Object} 500 - If the model fails or an internal error occurs.
+ *
+ * @example
+ * POST /smart-summary-firebase-v2
+ * {
+ *   "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+ *   "model": "openai"
+ * }
+ */
 app.post('/smart-summary-firebase-v2', async (req, res) => {
   try {
     const { url, model } = req.body;

--- a/index.js
+++ b/index.js
@@ -1013,16 +1013,18 @@ app.post('/smart-summary-firebase-v2', async (req, res) => {
 
     // Format frontmatter from metadata
     const frontmatter = `---
-title: "${metadata.title}"
-date: ${metadata.date}
-description: |
-  ${metadata.description}
-image: '${metadata.image}'
-tags:
-${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
-canonical_url: ${metadata.canonical_url}
-author: ${metadata.author}
----\n\n`;
+      title: "${metadata.title}"\n
+      date: ${metadata.date}\n
+      description: |
+        ${metadata.description}\n
+      image: '${metadata.image}'\n
+      tags:
+        - youtube
+      ${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
+      canonical_url: ${metadata.canonical_url}\n
+      author: ${metadata.author}
+      ---\n\n
+      # ${metadata.title}\n`;
 
     const summaryWithFrontmatter = `${frontmatter}${plainSummary}`;
 

--- a/index.js
+++ b/index.js
@@ -711,7 +711,7 @@ app.post('/smart-transcript-v2', async (req, res) => {
 
       // 🆕 Metadata to save
       const title = videoInfo.videoDetails.title;
-      const description = videoInfo.videoDetails.shortDescription?.split('\n')[0] || '';
+      const description = videoInfo.videoDetails.description?.split('\n')[0] || '';
       const publishedAt = videoInfo.videoDetails.publishDate || new Date().toISOString().split('T')[0];
       const date = publishedAt.replace(/-/g, '/');
       const image = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;

--- a/index.js
+++ b/index.js
@@ -1023,7 +1023,8 @@ tags:
 ${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
 canonical_url: ${metadata.canonical_url}\n
 author: ${metadata.author}
----\n\n
+---
+![](![](https://www.youtube.com/watch?v=${videoId}))
 # ${metadata.title}\n`;
 
     const summaryWithFrontmatter = `${frontmatter}${plainSummary}`;

--- a/index.js
+++ b/index.js
@@ -1001,7 +1001,7 @@ app.post('/smart-summary-firebase-v2', async (req, res) => {
     }
 
     // 🧠 Call your deployed endpoint that returns both summary and tags
-    const response = await axios.post('https://your-deployed-domain.vercel.app/api/openai-chat-youtube-transcript-v2', {
+    const response = await axios.post(modelUrl, {
       videoId,
     });
 

--- a/index.js
+++ b/index.js
@@ -1024,7 +1024,7 @@ ${(metadata.tags || []).map(tag => `  - ${tag}`).join('\n')}
 canonical_url: ${metadata.canonical_url}\n
 author: ${metadata.author}
 ---
-![](![](https://www.youtube.com/watch?v=${videoId}))
+![](https://www.youtube.com/watch?v=${videoId})
 # ${metadata.title}\n`;
 
     const summaryWithFrontmatter = `${frontmatter}${plainSummary}`;

--- a/index.js
+++ b/index.js
@@ -713,7 +713,7 @@ app.post('/smart-transcript-v2', async (req, res) => {
       const title = videoInfo.videoDetails.title;
       const description = videoInfo.videoDetails.description?.split('\n')[0] || '';
       const publishedAt = videoInfo.videoDetails.publishDate || new Date().toISOString().split('T')[0];
-      const date = publishedAt.replace(/-/g, '/');
+      const date = publishedAt;
       const image = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
 
       // Naive tag inference (improve later)


### PR DESCRIPTION
### ✨ Add AI-Generated Summary & Tags Support (`/smart-summary-firebase-v2` & `/smart-transcript-v2`)

#### ✅ What's New

* **`/smart-transcript-v2`**

  * Fetches YouTube transcript and metadata (title, description, publish date, thumbnail).
  * Infers basic tags from video title.
  * Stores everything in the `transcripts` Firestore collection.

* **`/smart-summary-firebase-v2`**

  * Calls the OpenAI-powered `openai-chat-youtube-transcript-v2` service to generate:

    * A markdown-formatted summary (with frontmatter)
    * A list of SEO-style tags
  * Stores the result in `summaries` and updates `tags` in `transcripts`.

#### 🧠 Benefits

* Improved content indexing and retrieval via smart tags.
* Clean, copy-ready summaries compatible with Obsidian or static blogs.
* Faster and cheaper summarization with Firebase caching.

#### 📝 Related Changes

* Updated `.vercel.json` to support proper API routing.
* Enhanced error handling and validation across both endpoints.
* README and documentation updated to reflect the new endpoints.
