### PR TITLE
Add `/smart-summary-firebase-v3` Endpoint for Enhanced Summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,29 @@ Generates a markdown-formatted AI summary with frontmatter and tags. Caches both
 
 ---
 
+### 🧠 POST `/smart-summary-firebase-v3`
+
+This endpoint improves upon v2 by retrieving extended video metadata from Firestore (such as category, video author, publish date) and formatting the summary as a Markdown document with a full YAML frontmatter block. The summary is cached in Firestore to avoid redundant AI calls.
+
+**Request:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
+  "model": "chatgpt" // or "anthropic", "deepseek", etc.
+}
+```
+
+**Response**
+
+```json
+{
+  "summary": "---\\ntitle: \\"...\\",\\ndate: ...\\ndescription: ...\\n...\\n---\\nSummary content...",
+  "fromCache": false
+}
+```
+---
+
 ## PM2 Notes
 
 To start the server with PM2:

--- a/documentation.md
+++ b/documentation.md
@@ -371,6 +371,41 @@ A debug endpoint that returns the IP address and region of the requestor.
 
 ---
 
+### 11. **POST `/smart-summary-firebase-v3`**
+
+This endpoint enhances `/smart-summary-firebase-v2` by retrieving rich metadata (e.g., category, video author, published date) from Firestore. It generates a structured summary using an external model endpoint and wraps the result in a Markdown document with YAML frontmatter. The summary is then cached in Firestore for future requests.
+
+#### **Request Body:**
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
+  "model": "chatgpt"  // Or "anthropic", "deepseek", etc.
+}
+```
+
+- **`url`**: Full YouTube video URL.
+- **`model`**: AI model to use for summary generation.
+
+### **Response**
+
+```json
+{
+  "summary": "---\\ntitle: \\"...\\",\\ndate: ...\\ndescription: ...\\ntags: [...]\\n---\\nSummary content...",
+  "fromCache": false
+}
+```
+- **`summary`**: Full Markdown output with frontmatter.
+- **`fromCache`**: true if retrieved from Firestore, otherwise false.
+
+### **Highlights:**
+
+- Adds extended metadata to the summary frontmatter (e.g., video_author, published_date, video_id, etc.).
+- Sends only the videoId to the AI endpoint for summary generation.
+- Stores result in summaries collection in Firestore.
+
+---
+
 ## **Firebase Firestore Caching**
 
 The service uses Firebase Firestore to cache transcripts and summaries for YouTube videos. If a transcript or summary has already been processed for a video, it will be fetched from Firestore to avoid redundant processing.

--- a/index.js
+++ b/index.js
@@ -1150,7 +1150,7 @@ description: |
   ${metadata.description}
 image: '${metadata.image}
 duration: ${metadata.duration}
-tags: ${tags}
+tags: ${metadata.tags}
 canonical_url: ${metadata.canonical_url}
 author: ${metadata.author}
 video_author: ${metadata.video_author}

--- a/index.js
+++ b/index.js
@@ -1151,7 +1151,8 @@ description: |
   ${metadata.description}
 image: '${metadata.image}
 duration: ${metadata.duration}
-tags: ${metadata.tags.map(tag => `  - ${tag}`).join('\n')}
+tags: 
+${metadata.tags.map(tag => `  - ${tag}`).join('\n')}
 canonical_url: ${metadata.canonical_url}
 author: ${metadata.author}
 video_author: ${metadata.video_author}

--- a/index.js
+++ b/index.js
@@ -1095,6 +1095,45 @@ author: ${metadata.author}
   }
 });
 
+/**
+ * @route POST /smart-summary-firebase-v3
+ * @description
+ * Handles summarization of a YouTube video's transcript using an external AI model.
+ * - Checks Firebase Firestore for a cached summary.
+ * - If not found, retrieves transcript metadata.
+ * - Sends a request to a model endpoint to generate the summary.
+ * - Constructs a full Markdown document with YAML frontmatter.
+ * - Saves the summary to the `summaries` Firestore collection.
+ * 
+ * @param {Object} req - Express request object.
+ * @param {Object} req.body - Request body.
+ * @param {string} req.body.url - Full YouTube video URL. Required.
+ * @param {string} req.body.model - Model name to use for summarization (e.g., "chatgpt", "anthropic"). Required.
+ * 
+ * @param {Object} res - Express response object.
+ * 
+ * @returns {Object} 200 - Success response with the generated summary:
+ * {
+ *   summary: string,        // Markdown content including YAML frontmatter
+ *   fromCache: boolean      // True if returned from Firebase cache, false if generated
+ * }
+ * 
+ * @returns {Object} 400 - If URL or model is missing or invalid:
+ * {
+ *   message: string
+ * }
+ * 
+ * @returns {Object} 404 - If no transcript was found for the given video:
+ * {
+ *   message: 'Transcript not found for this video.'
+ * }
+ * 
+ * @returns {Object} 500 - On internal errors or failed model response:
+ * {
+ *   message: string
+ * }
+ */
+
 app.post('/smart-summary-firebase-v3', async (req, res) => {
   try {
     const { url, model } = req.body;
@@ -1149,7 +1188,7 @@ date: ${metadata.date}
 category: ${metadata.category}
 description: |
   ${metadata.description}
-image: '${metadata.image}
+image: '${metadata.image}'
 duration: ${metadata.duration}
 tags: 
 ${metadata.tags.map(tag => `  - ${tag}`).join('\n')}

--- a/index.js
+++ b/index.js
@@ -1097,7 +1097,7 @@ author: ${metadata.author}
 
 app.post('/smart-summary-firebase-v3', async (req, res) => {
   try {
-    const { url, model, category } = req.body;
+    const { url, model } = req.body;
     if (!url) return res.status(400).json({ message: 'URL is required' });
 
     const videoId = ytdl.getURLVideoID(url);

--- a/index.js
+++ b/index.js
@@ -1151,7 +1151,7 @@ description: |
   ${metadata.description}
 image: '${metadata.image}
 duration: ${metadata.duration}
-tags: ${metadata.tags}
+tags: ${metadata.tags.map(tag => `  - ${tag}`).join('\n')}
 canonical_url: ${metadata.canonical_url}
 author: ${metadata.author}
 video_author: ${metadata.video_author}

--- a/index.js
+++ b/index.js
@@ -1122,6 +1122,7 @@ app.post('/smart-summary-firebase-v3', async (req, res) => {
     }
 
     const metadata = transcriptSnap.data();
+    console.log('Transcript Metadata:', metadata);
 
     // Ensure model is valid
     const modelUrl = modelUrls[model];
@@ -1169,7 +1170,7 @@ published_date: ${metadata.published_date}
       {
         summary: summaryWithFrontmatter,
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        tags,
+        tags: metadata.tags,
       },
       { merge: true }
     );

--- a/index.js
+++ b/index.js
@@ -1145,7 +1145,7 @@ app.post('/smart-summary-firebase-v3', async (req, res) => {
     const frontmatter = `---
 title: "${metadata.title}"
 date: ${metadata.date}
-category: ${category}
+category: ${metadata.category}
 description: |
   ${metadata.description}
 image: '${metadata.image}
@@ -1177,7 +1177,7 @@ published_date: ${metadata.published_date}
     res.json({ summary: summaryWithFrontmatter, fromCache: false });
 
   } catch (err) {
-    console.error('Error in /smart-summary-firebase-v2:', err);
+    console.error('Error in /smart-summary-firebase-v3:', err);
     res.status(500).json({ message: 'Error generating smart summary' });
   }
 });


### PR DESCRIPTION
### 🔀 Pull Request: Add `/smart-summary-firebase-v3` Endpoint for Enhanced Summaries

#### 📌 Summary

This PR introduces a new API endpoint, **`/smart-summary-firebase-v3`**, which extends the smart summary capabilities of the existing v2 service by:

* Using richer metadata from the `transcripts` Firestore collection (e.g. `video_author`, `category`, `published_date`, `duration`, etc.)
* Generating a complete Markdown document with YAML frontmatter
* Supporting multiple AI model providers (`chatgpt`, `anthropic`, `deepseek`, etc.)
* Storing the result in the `summaries` Firestore collection to support cache-based retrieval

---

#### ✅ What’s New

* ✨ New route: `POST /smart-summary-firebase-v3`
* 🔁 Reuses cached summaries if available
* 🧠 Sends `videoId` to the selected AI model endpoint for summary generation
* 📝 Constructs Markdown-formatted summaries with rich frontmatter:

  ```yaml
  ---
  title: "Video Title"
  date: 2025-05-01
  description: "..."
  tags: [...]
  video_author: "Channel Name"
  category: "Education"
  published_date: 2025-04-30
  duration: 820
  ...
  ---
  ```
* 🗃️ Stores results with `summary`, `updatedAt`, and `tags` in Firestore

---

#### 🧪 How to Test

```bash
POST /smart-summary-firebase-v3
Content-Type: application/json

{
  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
  "model": "chatgpt"
}
```

Expected Response:

```json
{
  "summary": "---\\ntitle: \\"...\\",\\ndate: ...\\ntags: [...]\\n---\\nSummary content...",
  "fromCache": false
}
```

---

#### 📚 Docs Updated

* [x] `README.md`
* [x] `documentation.md`

